### PR TITLE
fix: reference existing qrcode bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
 
 <!-- libs: pako (deflate), qrcode, marked (markdown) -->
 <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
+<script src="https://unpkg.com/qrcode@1.4.4/build/qrcode.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
 
 <script>


### PR DESCRIPTION
## Summary
- use qrcode v1.4.4 bundle from unpkg because v1.5.x lacks `qrcode.min.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c3e6397c8332ae85dbc497084a03