### PR TITLE
Move QR video detection to host

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,11 +75,19 @@
           <input id="inviteLink" class="grow mono" readonly />
           <button id="copyInvite" class="btn">Copy</button>
         </div>
+        <div class="row">
+          <button id="enableVideo" class="btn">Enable video</button>
+        </div>
       </div>
       <div id="answerBlock" class="hidden">
         <h4>Paste guest Answer</h4>
         <input id="answerInput" class="grow mono" placeholder="#answer=…" />
         <button id="applyAnswer" class="btn">Apply Answer</button>
+      </div>
+      <div id="videoBlock" class="hidden">
+        <h4>Video preview</h4>
+        <video id="localVideo" autoplay playsinline muted></video>
+        <video id="remoteVideo" autoplay playsinline></video>
       </div>
     </div>
 
@@ -96,11 +104,6 @@
           <input id="answerLink" class="grow mono" readonly />
           <button id="copyAnswer" class="btn">Copy</button>
         </div>
-      </div>
-      <div id="videoBlock" class="hidden">
-        <h4>Video preview</h4>
-        <video id="localVideo" autoplay playsinline muted></video>
-        <video id="remoteVideo" autoplay playsinline></video>
       </div>
     </div>
 
@@ -434,6 +437,9 @@
       // Render QR
       renderQr('qr', link);
 
+      // Enable video for scanning guest answer
+      $('enableVideo').onclick = () => { promptEnableVideo(pc); };
+
       // Apply guest's answer
       $('applyAnswer').onclick = async () => {
         const val = $('answerInput').value.trim();
@@ -511,7 +517,6 @@
       // Render QR
       renderQr('qrAnswer', link);
       $('guestAnswerBlock').classList.remove('hidden');
-      await promptEnableVideo(pc);
     };
 
     $('cancelGuest').onclick = () => {


### PR DESCRIPTION
## Summary
- Show QR invite with an "Enable video" button for hosts and display video preview on the host side
- Remove guest-side video usage so only hosts activate the camera

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973449f89c8332ab7dcfeabf74177b