### PR TITLE
Improve logging for guest answer QR scanning

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,6 +192,8 @@
         try { pc.addTrack(track, stream); } catch {}
       });
 
+      console.log('Video stream enabled; starting QR scan for guest answer');
+
       const video = $('localVideo');
       const statusEl = $('scanStatus');
       const canvas = document.createElement('canvas');
@@ -211,7 +213,11 @@
         ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
         const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
         const code = window.jsQR(img.data, canvas.width, canvas.height);
+        if (code) {
+          console.debug('QR scan data:', code.data);
+        }
         if (code && code.data.includes('#answer=')) {
+          console.log('Answer QR detected');
           const m = code.data.match(/#answer=([A-Za-z0-9\-_]+)/);
           if (m) {
             statusEl.textContent = 'Answer detected!';
@@ -220,6 +226,7 @@
               if (answerObj.room === room && answerObj.role === 'guest' && answerObj.sdpType === 'answer') {
                 await pc.setRemoteDescription({ type: 'answer', sdp: answerObj.sdp });
                 updatePills(roleText);
+                console.log('Answer applied from QR');
                 statusEl.textContent = 'Answer applied!';
                 $('answerBlock').classList.add('hidden');
                 video.classList.add('hidden');
@@ -227,12 +234,15 @@
                 scanning = false;
                 return;
               } else {
+                console.warn('Scanned answer does not match room/role', answerObj);
                 statusEl.textContent = 'Invalid answer';
               }
             } catch (e) {
-              console.error(e);
+              console.error('Failed to apply scanned answer', e);
               statusEl.textContent = 'Failed to apply answer';
             }
+          } else {
+            console.warn('QR code contained #answer but pattern did not match');
           }
         }
         requestAnimationFrame(scan);


### PR DESCRIPTION
## Summary
- add console logging when enabling video and scanning for guest answer QR codes
- log QR data, detection progress, and reasons for failures or mismatches

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689741b30eb88332a61593dd5ba17c86