### PR TITLE
Use worker-based QR scanner for live video

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,10 @@
 <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js"></script>
 <script src="https://unpkg.com/qrcode@1.4.4/build/qrcode.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/qr-scanner@1.4.2/qr-scanner.min.js"></script>
+<script>
+  QrScanner.WORKER_PATH = 'https://cdn.jsdelivr.net/npm/qr-scanner@1.4.2/qr-scanner-worker.min.js';
+</script>
 
 <script>
 (() => {
@@ -185,69 +188,57 @@
     const ok = window.confirm('Enable video?');
     if (!ok) return;
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ video: true });
-      $('localVideo').srcObject = stream;
-      $('videoBlock').classList.remove('hidden');
-      stream.getTracks().forEach(track => {
-        try { pc.addTrack(track, stream); } catch {}
-      });
-
-      console.log('Video stream enabled; starting QR scan for guest answer');
-
       const video = $('localVideo');
       const statusEl = $('scanStatus');
-      const canvas = document.createElement('canvas');
-      const ctx = canvas.getContext('2d');
-      let scanning = true;
       statusEl.textContent = 'Scanning for Answer QR…';
       statusEl.classList.remove('hidden');
 
-      async function scan() {
-        if (!scanning) return;
-        if (video.videoWidth === 0) {
-          requestAnimationFrame(scan);
-          return;
-        }
-        canvas.width = video.videoWidth;
-        canvas.height = video.videoHeight;
-        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-        const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
-        const code = window.jsQR(img.data, canvas.width, canvas.height);
-        if (code) {
-          console.debug('QR scan data:', code.data);
-        }
-        if (code && code.data.includes('#answer=')) {
-          console.log('Answer QR detected');
-          const m = code.data.match(/#answer=([A-Za-z0-9\-_]+)/);
-          if (m) {
-            statusEl.textContent = 'Answer detected!';
-            try {
-              const answerObj = inflateFromB64Url(m[1]);
-              if (answerObj.room === room && answerObj.role === 'guest' && answerObj.sdpType === 'answer') {
-                await pc.setRemoteDescription({ type: 'answer', sdp: answerObj.sdp });
-                updatePills(roleText);
-                console.log('Answer applied from QR');
-                statusEl.textContent = 'Answer applied!';
-                $('answerBlock').classList.add('hidden');
-                video.classList.add('hidden');
-                setTimeout(() => statusEl.classList.add('hidden'), 2000);
-                scanning = false;
-                return;
-              } else {
-                console.warn('Scanned answer does not match room/role', answerObj);
-                statusEl.textContent = 'Invalid answer';
+      const scanner = new QrScanner(
+        video,
+        async result => {
+          const text = result.data || result;
+          console.debug('QR scan data:', text);
+          if (text.includes('#answer=')) {
+            console.log('Answer QR detected');
+            const m = text.match(/#answer=([A-Za-z0-9\-_]+)/);
+            if (m) {
+              statusEl.textContent = 'Answer detected!';
+              try {
+                const answerObj = inflateFromB64Url(m[1]);
+                if (answerObj.room === room && answerObj.role === 'guest' && answerObj.sdpType === 'answer') {
+                  await pc.setRemoteDescription({ type: 'answer', sdp: answerObj.sdp });
+                  updatePills(roleText);
+                  console.log('Answer applied from QR');
+                  statusEl.textContent = 'Answer applied!';
+                  $('answerBlock').classList.add('hidden');
+                  video.classList.add('hidden');
+                  setTimeout(() => statusEl.classList.add('hidden'), 2000);
+                  await scanner.stop();
+                  scanner.destroy();
+                } else {
+                  console.warn('Scanned answer does not match room/role', answerObj);
+                  statusEl.textContent = 'Invalid answer';
+                }
+              } catch (e) {
+                console.error('Failed to apply scanned answer', e);
+                statusEl.textContent = 'Failed to apply answer';
               }
-            } catch (e) {
-              console.error('Failed to apply scanned answer', e);
-              statusEl.textContent = 'Failed to apply answer';
+            } else {
+              console.warn('QR code contained #answer but pattern did not match');
             }
-          } else {
-            console.warn('QR code contained #answer but pattern did not match');
           }
-        }
-        requestAnimationFrame(scan);
-      }
-      requestAnimationFrame(scan);
+        },
+        { returnDetailedScanResult: true, highlightScanRegion: true, highlightCodeOutline: true }
+      );
+
+      $('videoBlock').classList.remove('hidden');
+      await scanner.start();
+      console.log('Video stream enabled; starting QR scan for guest answer');
+
+      const stream = video.srcObject;
+      stream.getTracks().forEach(track => {
+        try { pc.addTrack(track, stream); } catch {}
+      });
     } catch (err) {
       console.error('video error', err);
     }


### PR DESCRIPTION
## Summary
- replace jsQR with qr-scanner and configure worker path
- handle live video scanning with QrScanner, highlighting scan region and code outlines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974605c0f88332b822a65f827924d6