### PR TITLE
fix: add AudioContext polyfill for sonicnet

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,11 @@
   <h2>Received messages</h2>
   <pre id="log"></pre>
 
+  <script>
+    // Provide legacy webkitAudioContext alias for older libraries
+    window.AudioContext = window.AudioContext || window.webkitAudioContext;
+    window.webkitAudioContext = window.webkitAudioContext || window.AudioContext;
+  </script>
   <script src="https://cdn.jsdelivr.net/gh/borismus/sonicnet.js/lib/build/sonicnet.js"></script>
   <script>
     // Encode a string into hexadecimal so it fits the limited alphabet


### PR DESCRIPTION
## Summary
- polyfill `webkitAudioContext` so sonicnet.js loads correctly

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/shared-checklist/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689800b31fac83329c72667f3bc04f7a