### PR TITLE
Link receive frequency to transmit tone

### DIFF
--- a/goertzel-detector.js
+++ b/goertzel-detector.js
@@ -93,7 +93,10 @@ class GoertzelDetector extends AudioWorkletProcessor {
             which = +1;
           }
           // nudge f0 slowly
-          if (which !== 0) this.f0 += 0.4 * which;
+          if (which !== 0) {
+            this.f0 += 0.4 * which;
+            if (this.f0 < 0) this.f0 = 0;
+          }
           if ((i % (this.M * 8)) === 0) this.resetBins();
         }
         this.clearBins();

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
           ><input type="checkbox" id="lockSpeed" /> Lock speed</label
         >
         <label class="pill"
-          ><input type="checkbox" id="trackFreq" checked /> Track
+          ><input type="checkbox" id="trackFreq" /> Track
           frequency</label
         >
       </div>

--- a/main.js
+++ b/main.js
@@ -35,10 +35,14 @@ import { MORSE, REV } from "./morse.js";
         const rxStatus = document.getElementById("rxStatus");
 
         wpm.addEventListener("input", () => (wpmVal.textContent = wpm.value));
-        tone.addEventListener(
-          "input",
-          () => (toneVal.textContent = tone.value)
-        );
+        tone.addEventListener("input", () => {
+          toneVal.textContent = tone.value;
+          if (workletNode)
+            workletNode.port.postMessage({
+              cmd: "setFreq",
+              f0: Number(tone.value),
+            });
+        });
         vol.addEventListener(
           "input",
           () => (volVal.textContent = Number(vol.value).toFixed(2))
@@ -205,7 +209,10 @@ import { MORSE, REV } from "./morse.js";
           });
           const src = ctx.createMediaStreamSource(mediaStream);
           workletNode = new AudioWorkletNode(ctx, "goertzel-detector", {
-            processorOptions: { f0: DEFAULT_TONE, track: trackFreq.checked },
+            processorOptions: {
+              f0: Number(tone.value),
+              track: trackFreq.checked,
+            },
           });
           workletNode.port.onmessage = (e) => {
             const d = e.data || {};


### PR DESCRIPTION
## Summary
- Use transmit tone slider to set receiver's center frequency
- Clamp tracking algorithm so F0 never goes negative
- Disable frequency tracking by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a09ea564083329cc17794da879559