### PR TITLE
Add tone detection indicator in listen mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,17 @@
       .status {
         min-height: 1.2em;
       }
+      .tone-indicator {
+        display: inline-block;
+        width: 0.75rem;
+        height: 0.75rem;
+        border-radius: 50%;
+        background: #ccc;
+        vertical-align: middle;
+      }
+      .tone-indicator.on {
+        background: #0c0;
+      }
     </style>
   </head>
   <body>
@@ -157,6 +168,8 @@
         <div class="mono" id="snr">–</div>
         <div>Status</div>
         <div class="mono" id="rxStatus">Idle</div>
+        <div>Tone</div>
+        <div><span id="toneIndicator" class="tone-indicator"></span></div>
       </div>
     </section>
 

--- a/main.js
+++ b/main.js
@@ -32,6 +32,7 @@ import { MORSE, REV } from "./morse.js";
         const f0El = document.getElementById("f0");
         const snrEl = document.getElementById("snr");
         const rxStatus = document.getElementById("rxStatus");
+        const toneIndicator = document.getElementById("toneIndicator");
 
         wpm.addEventListener("input", () => {
           wpmVal.textContent = wpm.value;
@@ -231,6 +232,7 @@ import { MORSE, REV } from "./morse.js";
           stopBtn.disabled = false;
           rxStatus.textContent = "Listening…";
           symbolBuf = "";
+          toneIndicator.classList.remove("on");
           updateUnitSamples();
           updateUnitDisplay();
         }
@@ -249,11 +251,17 @@ import { MORSE, REV } from "./morse.js";
           listenBtn.disabled = false;
           stopBtn.disabled = true;
           rxStatus.textContent = "Idle";
+          toneIndicator.classList.remove("on");
         }
 
         function handleEdge(on, span) {
-          if (on) processGap(span);
-          else processTone(span);
+          if (on) {
+            processGap(span);
+            toneIndicator.classList.add("on");
+          } else {
+            processTone(span);
+            toneIndicator.classList.remove("on");
+          }
         }
 
         function processTone(span) {


### PR DESCRIPTION
## Summary
- add visual tone indicator to receive panel
- toggle indicator on/off based on detected edges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3cf2eafc83329dcedcf28168add4