### PR TITLE
Speed up Morse tone gating

### DIFF
--- a/goertzel-detector.js
+++ b/goertzel-detector.js
@@ -11,11 +11,13 @@ class GoertzelDetector extends AudioWorkletProcessor {
 
     // Envelope & gating
     this.env = 0;
-    this.aEnv = Math.exp(-1 / (0.010 * this.sr)); // ~10ms LP
+    // Shorter envelope window so gating reacts quickly to tone edges
+    this.aEnv = Math.exp(-1 / (0.005 * this.sr)); // ~5ms LP
     this.noise = 1e-6;
     this.peak = 1e-5;
-    this.aNoise = Math.exp(-1 / (0.200 * this.sr));
-    this.aPeak = Math.exp(-1 / (0.200 * this.sr));
+    // Track noise and peak over a shorter ~50ms window
+    this.aNoise = Math.exp(-1 / (0.050 * this.sr));
+    this.aPeak = Math.exp(-1 / (0.050 * this.sr));
     this.stateOn = false;
     this.samplesSinceEdge = 0;
 


### PR DESCRIPTION
## Summary
- shorten envelope, noise, and peak tracking windows in goertzel detector so Morse tone edges are detected promptly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a41d1189c8332ba09024d1f9ff68e