### PR TITLE
Correct envelope timing for Morse reception

### DIFF
--- a/goertzel-detector.js
+++ b/goertzel-detector.js
@@ -11,13 +11,15 @@ class GoertzelDetector extends AudioWorkletProcessor {
 
     // Envelope & gating
     this.env = 0;
+    // Coefficients tuned for updates every M samples rather than each sample
+    const stepSec = this.M / this.sr;
     // Shorter envelope window so gating reacts quickly to tone edges
-    this.aEnv = Math.exp(-1 / (0.005 * this.sr)); // ~5ms LP
+    this.aEnv = Math.exp(-stepSec / 0.005); // ~5ms LP
     this.noise = 1e-6;
     this.peak = 1e-5;
     // Track noise and peak over a shorter ~50ms window
-    this.aNoise = Math.exp(-1 / (0.050 * this.sr));
-    this.aPeak = Math.exp(-1 / (0.050 * this.sr));
+    this.aNoise = Math.exp(-stepSec / 0.050);
+    this.aPeak = Math.exp(-stepSec / 0.050);
     this.stateOn = false;
     this.samplesSinceEdge = 0;
 


### PR DESCRIPTION
## Summary
- Fix envelope and noise trackers in goertzel detector to account for block processing
- Gate now reacts within ~5ms and no longer holds tone for whole letters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a49a1db2483329f33dca8556bc2a3